### PR TITLE
DOC: Document homepage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ dynamic = ["version"]
 
 [tool.setuptools]
 packages = ["mne_faster"]
+readme = {file = ["README.rst"]}
 
 [tool.setuptools.dynamic]
 version = {attr = "mne_faster.__version__"}
-readme = {file = ["README.rst"]}
 
 [tool.pytest.ini_options]
 addopts = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = ["mne"]
 dynamic = ["version"]
+readme = {content-type = "text/x-rst", file = "README.rst"}
 
 [project.urls]
 "Bug Tracker" = "https://github.com/wmvanvliet/mne-faster/issues/"
@@ -33,7 +34,6 @@ dynamic = ["version"]
 
 [tool.setuptools]
 packages = ["mne_faster"]
-readme = {content-type = "text/x-rst", file = "README.rst"}
 
 [tool.setuptools.dynamic]
 version = {attr = "mne_faster.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 
 [tool.setuptools]
 packages = ["mne_faster"]
-readme = {file = ["README.rst"]}
+readme = {content-type = "text/x-rst", file = "README.rst"}
 
 [tool.setuptools.dynamic]
 version = {attr = "mne_faster.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dynamic = ["version"]
 [project.urls]
 "Bug Tracker" = "https://github.com/wmvanvliet/mne-faster/issues/"
 "Source Code" = "https://github.com/wmvanvliet/mne-faster"
+"Homepage" = "https://github.com/wmvanvliet/mne-faster"
 
 [tool.setuptools]
 packages = ["mne_faster"]
@@ -53,7 +54,7 @@ indent-width = 4
 [tool.ruff.lint]
 select = ["E", "F", "D", "W"]
 ignore = ["D107", "D203", "D213"]
-per-file-ignores = {"examples/*.py" = ["D205", "D400", "D415", "D212"], "__init__.py" = ["E402"]} 
+per-file-ignores = {"examples/*.py" = ["D205", "D400", "D415", "D212"], "__init__.py" = ["E402"]}
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
Let no good deed go unpunished :)

Transition to `pyproject.toml` dropped the homepage, which is there for almost all projects, causing:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/26654/workflows/21bdfb4d-1327-4175-bc1e-2829f82b4fd8/jobs/71541